### PR TITLE
Fixed inverse merge, improved logging during debugging

### DIFF
--- a/configurator/src/main/java/com/devonfw/ide/configurator/logging/Log.java
+++ b/configurator/src/main/java/com/devonfw/ide/configurator/logging/Log.java
@@ -1,9 +1,13 @@
 package com.devonfw.ide.configurator.logging;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.logging.FileHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 
 import com.devonfw.ide.configurator.Configurator;
 
@@ -21,11 +25,19 @@ public class Log {
   static {
     try {
       FileHandler logFileHandler = new FileHandler("Configurator.log");
-      logFileHandler.setLevel(Level.ALL);
-      logFileHandler.setFormatter(new SimpleFormatter());
+      logFileHandler.setLevel(Level.FINEST);
+      LogFormatter formatter = new LogFormatter();
+      logFileHandler.setFormatter(formatter);
       LOGGER.addHandler(logFileHandler);
+      LOGGER.setLevel(Level.FINEST);
+      Logger globalLogger = Logger.getLogger("");
+      globalLogger.setLevel(Level.FINEST);
+      for (Handler handler : globalLogger.getHandlers()) {
+        handler.setFormatter(formatter);
+      }
     } catch (Exception e) {
       System.err.println("Could not open log file");
+      e.printStackTrace();
     }
   }
 
@@ -47,4 +59,14 @@ public class Log {
     Log.LOGGER.severe(message);
   }
 
+  public static class LogFormatter extends Formatter {
+
+    @Override
+    public String format(LogRecord record) {
+
+      return String.format("%1$s [%2$-7s] %3$s\n",
+          new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(new Date(record.getMillis())),
+          record.getLevel().getName(), formatMessage(record));
+    }
+  }
 }

--- a/configurator/src/main/java/com/devonfw/ide/configurator/merge/DirectoryMerger.java
+++ b/configurator/src/main/java/com/devonfw/ide/configurator/merge/DirectoryMerger.java
@@ -78,10 +78,13 @@ public class DirectoryMerger implements FileMerger {
     int lastDot = filename.lastIndexOf('.');
     if (lastDot > 0) {
       String extension = filename.substring(lastDot);
+      Log.LOGGER.finest("Extension is " + extension);
       FileTypeMerger merger = this.extension2mergerMap.get(extension);
       if (merger != null) {
         return merger;
       }
+    } else {
+      Log.LOGGER.finest("No extension for " + file);
     }
     return this.fallbackMerger;
   }
@@ -94,12 +97,18 @@ public class DirectoryMerger implements FileMerger {
         Log.LOGGER.warning("Workspace is missing directory: " + workspaceFile);
         return;
       }
+      Log.LOGGER.fine("Traversing directory " + updateFile);
       for (File child : updateFile.listFiles()) {
-        inverseMerge(workspaceFile, resolver, addNewProperties, new File(updateFile, child.getName()));
+        inverseMerge(new File(workspaceFile, child.getName()), resolver, addNewProperties,
+            new File(updateFile, child.getName()));
       }
     } else if (workspaceFile.exists()) {
+      Log.LOGGER.fine("Start merging of changes from workspace back to file " + updateFile);
       FileTypeMerger merger = getMerger(workspaceFile);
+      Log.LOGGER.finest("Using merger " + merger.getClass().getSimpleName());
       merger.inverseMerge(workspaceFile, resolver, addNewProperties, updateFile);
+    } else {
+      Log.LOGGER.warning("No such file or directory: " + updateFile);
     }
   }
 


### PR DESCRIPTION
After refactoring inverse merge (`update-eclipse-workspace-settings`) was broken. Some variables were not substituted anymore. To trace down the error I improved the logging that was not yet helpful enough. Further I discovered that on linux and mac the system resolves links (which are especially required to make eclipse work under macos) and therefore the re-substitution of the paths does not work as expected. I extended the solution to resolve symbolic links and allow also the substitution of the results as far as symlinks are involved.