### PR TITLE
#169: linux/mac setup fails with *.xz files

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -355,7 +355,7 @@ function doExtract() {
     doRunCommand "tar xf '${1}' -C '${target_dir}'"
   elif [ "${ext}" = ".xz" ]
   then
-    doRunCommand "tar xf '${1}' -C '${target_dir}'"
+    doRunCommand "tar xJf '${1}' -C '${target_dir}'"
   elif [ "${ext}" = ".tgz" ]
   then
     doRunCommand "tar xfz '${1}' -C '${target_dir}'"

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -353,6 +353,9 @@ function doExtract() {
   elif [ "${ext}" = ".tar" ]
   then
     doRunCommand "tar xf '${1}' -C '${target_dir}'"
+  elif [ "${ext}" = ".xz" ]
+  then
+    doRunCommand "tar xf '${1}' -C '${target_dir}'"
   elif [ "${ext}" = ".tgz" ]
   then
     doRunCommand "tar xfz '${1}' -C '${target_dir}'"


### PR DESCRIPTION
The `functions` file has been extended by handling the `.xz` files with `tar xf file`