### PR TITLE
#229: fixe to preserve workspace that was reset to main

### DIFF
--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -16,7 +16,7 @@ Please note that we are trying to minimize any potential side-effect from `devon
 |`DEVON_HOME_DIR`|`~`|The platform independent home directory of the current user. In some edge-cases (e.g. in cygwin) this differs from `~` to ensure a central home directory for the user on a single machine in any context or environment.
 |`DEVON_IDE_TOOLS`|`java mvn eclipse vscode node npm ng`|List of tools that should be installed and upgraded by default for your current IDE.
 |*`DEVON_OLD_PATH`*|`...`|A "backup" of `PATH` before it was extended by `devon` to allow restting it. Internal variable that should never be set or tweaked.
-|`WORKSPACE`|`main`|The link:workspaces.asciidoc[workspace] you are currently in. Defaults to `main` if you are not inside a link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
+|*`WORKSPACE`*|`main`|The link:workspaces.asciidoc[workspace] you are currently in. Defaults to `main` if you are not inside a link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
 |`WORKSPACE_PATH`|`$DEVON_IDE_HOME/workspaces/$WORKSPACE`|Absoulte path to current link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
 |*`JAVA_HOME`*|`$DEVON_IDE_HOME/software/java`|Path to JDK
 |`SETTINGS_PATH`|`$DEVON_IDE_HOME/settings`|Path to your link:settings.asciidoc[settings]. To keep `oasp4j-ide` legacy behaviour set this to `$DEVON_IDE_HOME/workspaces/main/development/settings`.

--- a/scripts/src/main/resources/scripts/command/eclipse
+++ b/scripts/src/main/resources/scripts/command/eclipse
@@ -153,7 +153,7 @@ function doAddPlugin() {
 
 function doStartEclipse() {
   doConfigureEclipse -u
-  echo "launching Eclipse..."
+  echo "launching Eclipse in workspace ${WORKSPACE} at ${WORKSPACE_PATH}"
   if doIsWindows
   then
     # shellcheck disable=SC2086

--- a/scripts/src/main/resources/scripts/devon
+++ b/scripts/src/main/resources/scripts/devon
@@ -29,6 +29,7 @@ do
         if [ -d "${L_WKS}" ]
         then
           WORKSPACE="${L_RESTDIR}"
+          export WORKSPACE
         fi
       fi
     fi


### PR DESCRIPTION
* fix for #229 eclipse always launched in main workspace